### PR TITLE
feat: start agent design sessions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import Chat from "./pages/Chat.jsx";
 
 // New page:
 import AdminDownloads from "./pages/AdminDownloads.tsx";
+import AgentDesigner from "./pages/AgentDesigner.jsx";
 
 function ChatOnlyLogsButton() {
   const location = useLocation();
@@ -62,6 +63,7 @@ export default function App() {
           {/* Auth / chat */}
           <Route path="/login" element={<Login />} />
           <Route path="/chat" element={<Chat />} />
+          <Route path="/agent-designer" element={<AgentDesigner />} />
           {/* Chat2 removed */}
 
           {/* Admin logs (backend enforces auth) */}

--- a/src/pages/AgentDesigner.jsx
+++ b/src/pages/AgentDesigner.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../hooks/useAuth";
+import { startDesign } from "../services/agentDesign";
+
+export default function AgentDesigner() {
+  const { user, loading } = useAuth();
+  const [idea, setIdea] = useState("");
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-[60vh] text-sm opacity-80">
+        Loading your session…
+      </div>
+    );
+  }
+
+  if (!user) return <Navigate to="/login" replace />;
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError("");
+    try {
+      const res = await startDesign(idea);
+      setResult(res);
+    } catch (err) {
+      setError(err.message || String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 900, margin: "0 auto", padding: 16 }}>
+      <h1 className="text-2xl font-bold mb-4">Agent Designer</h1>
+      {!result ? (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <textarea
+            className="w-full border rounded p-2"
+            rows={4}
+            placeholder="Describe your agent idea..."
+            value={idea}
+            onChange={(e) => setIdea(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+            disabled={submitting || !idea.trim()}
+          >
+            {submitting ? "Starting..." : "Start Design"}
+          </button>
+          {error && <div className="text-red-600 text-sm">{error}</div>}
+        </form>
+      ) : (
+        <div className="space-y-2">
+          <p className="opacity-80">Design started.</p>
+          <div className="text-sm">ID: {result.designId}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -1,12 +1,13 @@
 // src/pages/Chat.jsx
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
 import { useAuth } from "../hooks/useAuth";
 import { streamChat } from "../services/chat";
 
 export default function Chat() {
   // ---- Auth guard inside the component ----
   const { user, loading } = useAuth();
+  const navigate = useNavigate();
 
   // Chat state
   const [messages, setMessages] = useState([
@@ -109,8 +110,31 @@ export default function Chat() {
 
   return (
     <div className="chat-page" style={{ maxWidth: 900, margin: "0 auto", padding: 16, display: 'flex', flexDirection: 'column', minHeight: 'calc(100dvh - 140px)' }}>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: isSmall ? "column" : "row",
+          justifyContent: "space-between",
+          alignItems: isSmall ? "stretch" : "center",
+          gap: 8,
+          marginBottom: 12,
+        }}
+      >
         <h1 className="text-2xl font-bold">Chat</h1>
+        <button
+          onClick={() => navigate("/agent-designer")}
+          style={{
+            padding: "6px 10px",
+            borderRadius: 8,
+            border: "1px solid #0b5cff",
+            background: "#0b5cff",
+            color: "#fff",
+            cursor: "pointer",
+            width: isSmall ? "100%" : "auto",
+          }}
+        >
+          Design an Agent
+        </button>
       </div>
 
       <div

--- a/src/services/agentDesign.ts
+++ b/src/services/agentDesign.ts
@@ -1,0 +1,15 @@
+// src/services/agentDesign.ts
+export type StartDesignResponse = { ok: boolean; designId: string; idea: string };
+
+export async function startDesign(idea: string): Promise<StartDesignResponse> {
+  const resp = await fetch("/api/design/start", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ idea }),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`Design start ${resp.status}: ${text.slice(0, 200)}`);
+  }
+  return (await resp.json()) as StartDesignResponse;
+}

--- a/worker/handlers/agentDesigner.ts
+++ b/worker/handlers/agentDesigner.ts
@@ -1,0 +1,16 @@
+import { json, bad } from "../lib/responses";
+import { rid } from "../lib/ids";
+
+export async function start(request: Request): Promise<Response> {
+  try {
+    const body = await request.json().catch(() => null) as { idea?: string } | null;
+    const idea = body?.idea?.trim();
+    if (!idea) {
+      return bad(400, "missing idea", rid());
+    }
+    const designId = rid();
+    return json({ ok: true, designId, idea });
+  } catch (err: any) {
+    return bad(500, err?.message || "internal error", rid());
+  }
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -10,6 +10,7 @@ export { DownloadLog } from "./do/DownloadLog";
 import * as auth from "./handlers/auth";
 import * as chat from "./handlers/chat";
 import * as notify from "./handlers/notify";
+import * as design from "./handlers/agentDesigner";
 import { setDownloadEmailCookie, clearDownloadEmailCookie } from "./handlers/email";
 import { handleHealth } from "./handlers/health";
 import { DBG } from "./env";
@@ -121,6 +122,11 @@ export default {
           status,
           headers: { "content-type": "application/json" },
         });
+      }
+
+      // Agent design: start session
+      if (pathname === "/api/design/start" && request.method === "POST") {
+        return await design.start(request);
       }
 
       // Chat stream (both GET diagnostics and POST chat)


### PR DESCRIPTION
## Summary
- add start-design endpoint and frontend helper
- allow logged-in users to submit an idea and receive a design id

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c553fe346c832f8caf4a520cf94b05